### PR TITLE
Add public url as arg in build time to allow hosting on paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN npm ci
 COPY . .
 
 # Run the build command to create production-ready static files
+ARG PUBLIC_URL
 RUN npm run build
 
 # Second stage: Use Nginx to serve the built files


### PR DESCRIPTION
## Summary

This pull request adds an `ARG PUBLIC_URL` to the `Dockerfile`. This allows the React build’s `PUBLIC_URL` environment variable to be set at build time, enabling dynamic substitution of asset paths and links in `index.html` and throughout the app.

## Details

- Added `ARG PUBLIC_URL` to the `Dockerfile`.
- This argument can now be passed as a build argument to set the base public URL for the React application.
- This is useful for deployments where the app is served from a subpath (e.g., `/app/` instead of `/`).

## Usage

To build the Docker image with a custom public URL:

```sh
docker build --build-arg PUBLIC_URL=/custom-path/ -t my-app .
```

## Motivation

Setting the `PUBLIC_URL` at build time allows for more flexible deployments and correct asset resolution in environments where the base path is not `/`.